### PR TITLE
Add additional app launch scenarios for OOM tracking

### DIFF
--- a/JRFMemoryNoodler/JRFMemoryNoodler.h
+++ b/JRFMemoryNoodler/JRFMemoryNoodler.h
@@ -34,4 +34,20 @@ typedef BOOL (^JRFCrashDetector)();
 + (void)beginMonitoringMemoryEventsWithHandler:(nonnull JRFOutOfMemoryEventHandler)handler
                                  crashDetector:(nullable JRFCrashDetector)crashDetector;
 
+
+/**
+  You should call this when your application receives a silent push notification. This will allow JRFMemoryNoodler to track an application launch that occurred from a silent push notification.
+  Call this if your application is not in the foreground and during:
+  `- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))fetchCompletionHandler`
+ */
++ (void)markSilentPushNotificationEvent;
+
+/**
+ You should call this when your application wakes up to perform work in the background. This will allow JRFMemoryNoodler to track an application launch that occurred from a silent push notification.
+ Call this during:
+ `- (void)application:(UIApplication *)application performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult result))fetchCompletionHandler`
+ */
++ (void)markBackgroundFetchEvent;
+
 @end
+

--- a/JRFMemoryNoodlerTests/JRFMemoryNoodlerTests.m
+++ b/JRFMemoryNoodlerTests/JRFMemoryNoodlerTests.m
@@ -49,6 +49,16 @@
     [self checkMemoryNoodlerWithExpectation:NO shouldBeInForeground:NO didCrash:YES];
 }
 
+- (void)testSilentPushNotificationDoesNotTriggerOutOfMemoryWarning {
+    [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"JRFSilentPushNotificationKey"];
+    [self checkMemoryNoodlerWithExpectation:NO shouldBeInForeground:YES didCrash:NO];
+}
+
+- (void)testBackgroundFetchDoesNotTriggerOutOfMemoryWarning {
+    [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"JRFBackgroundFetchKey"];
+    [self checkMemoryNoodlerWithExpectation:NO shouldBeInForeground:YES didCrash:NO];
+}
+
 - (void)testIntentionalQuitPathNameIsStable {
     const char *pathname1 = [JRFPathUtilities intentionalQuitPathname];
     const char *pathname2 = [JRFPathUtilities intentionalQuitPathname];


### PR DESCRIPTION
Summary:
OOM tracking is based of the blog post from Facebook https://code.fb.com/ios/reducing-fooms-in-the-facebook-ios-app/

This requires a process-of-elimination to determine if a launch is due to an OOM crash by marking every legitimate reason that an application could start. The article did not cover ways that the app may be launched from the OS which are background fetches and silent push notifications currently.

  New additions in this PR
  - Track app launches for silent notifications and background fetch
  - Don't report OOMs if the previous session was for these reasons.